### PR TITLE
Fixed missing required member 'storeOp'

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -98,7 +98,7 @@ import shaderCode from "./triangle.wgsl";
     });
 
     var renderPassDesc = {
-        colorAttachments: [{view: undefined, loadValue: [0.3, 0.3, 0.3, 1]}],
+        colorAttachments: [{view: undefined, loadValue: [0.3, 0.3, 0.3, 1], storeOp: "store"}],
         depthStencilAttachment: {
             view: depthTexture.createView(),
             depthLoadValue: 1.0,


### PR DESCRIPTION
Fixed missing required member 'storeOp' in instance of GPURenderPassColorAttachment dictionary which caused error on Firefox Nightly (for some reason it worked quite well under Chrome Canary).
At first, thought to submit an issue but then decided to just fix it myself and make contribution.

At Firefox Nightly it looked like this. Canary hadn't complained.
![image](https://user-images.githubusercontent.com/2073223/145230012-d0b841cf-937f-4d34-9b77-623f53ad7a0e.png)
