### PR TITLE
Update triangle sample to conform to latest WebGPU spec

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -98,12 +98,14 @@ import shaderCode from "./triangle.wgsl";
     });
 
     var renderPassDesc = {
-        colorAttachments: [{view: undefined, loadValue: [0.3, 0.3, 0.3, 1], storeOp: "store"}],
+        colorAttachments: [{view: undefined, loadOp: "clear", clearValue: [0.3, 0.3, 0.3, 1], storeOp: "store"}],
         depthStencilAttachment: {
             view: depthTexture.createView(),
-            depthLoadValue: 1.0,
+            depthLoadOp: "clear",
+            depthClearValue: 1.0,
             depthStoreOp: "store",
-            stencilLoadValue: 0,
+            stencilLoadOp: "clear",
+            stencilClearValue: 0,
             stencilStoreOp: "store"
         }
     };
@@ -130,7 +132,7 @@ import shaderCode from "./triangle.wgsl";
         renderPass.setVertexBuffer(0, dataBuf);
         renderPass.draw(3, 1, 0, 0);
 
-        renderPass.endPass();
+        renderPass.end();
         device.queue.submit([commandEncoder.finish()]);
     }
 })();

--- a/src/triangle.wgsl
+++ b/src/triangle.wgsl
@@ -2,17 +2,17 @@
 type float4 = vec4<f32>;
 
 struct VertexInput {
-    [[location(0)]] position: float4;
-    [[location(1)]] color: float4;
+    @location(0) position: float4,
+    @location(1) color: float4,
 };
 
 struct VertexOutput {
     // This is the equivalent of gl_Position in GLSL
-    [[builtin(position)]] position: float4;
-    [[location(0)]] color: float4;
+    @builtin(position) position: float4,
+    @location(0) color: float4,
 };
 
-[[stage(vertex)]]
+@stage(vertex)
 fn vertex_main(vert: VertexInput) -> VertexOutput {
     var out: VertexOutput;
     out.color = vert.color;
@@ -20,7 +20,7 @@ fn vertex_main(vert: VertexInput) -> VertexOutput {
     return out;
 };
 
-[[stage(fragment)]]
-fn fragment_main(in: VertexOutput) -> [[location(0)]] float4 {
+@stage(fragment)
+fn fragment_main(in: VertexOutput) -> @location(0) float4 {
     return float4(in.color);
 }


### PR DESCRIPTION
This change updates the triangle sample to conform to recent changes to the WebGPU spec.

API changes:
- loadValue replaced by loadOp and clearValue
- stencilLoadValue replaced by stencilLoadOp and stencilClearValue
- endPass() replaced by end() on render passes

Shader changes:
- [[xyz]] style attributes replaced by @xyz style
- Struct member separator is now comma (was semicolon)
